### PR TITLE
feat: レシート撮影による家計簿入力の自動補完を追加

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,47 @@
+name: deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# 同時に複数のデプロイが走らないようにする
+concurrency:
+  group: deploy-functions
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Workload Identity 連携に必須
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      # postinstall で firebase-cloud-functions 側の依存も入る
+      # （firebase.json の predeploy で eslint が走るため必要）
+      - name: yarn install
+        run: yarn install --frozen-lockfile
+
+      - name: run lint
+        run: yarn lint
+
+      - id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: fir-cloud-functions-trial
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+          # GOOGLE_APPLICATION_CREDENTIALS を firebase CLI に渡すため
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: deploy functions
+        run: npx firebase deploy --only functions --project fir-cloud-functions-trial --non-interactive

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ node_modules/
 # dotenv environment variables file
 .env
 
+# Firebase Cloud Functions のエミュレータ用シークレット
+firebase-cloud-functions/.env.local
+
 # Node
 **/node_modules/*
 

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ node_modules/
 
 # Firebase Cloud Functions のエミュレータ用シークレット
 firebase-cloud-functions/.env.local
+firebase-cloud-functions/.secret.local
 
 # Node
 **/node_modules/*

--- a/README.md
+++ b/README.md
@@ -55,6 +55,74 @@ App Engine のデフォルトサービスアカウントはプロジェクトレ
 `secretmanager.versions.access` はオーナーには含まれるが編集者・閲覧者には含まれないため、
 手順3の`シークレット アクセサー`の付与は必須。
 
+## CI からの Cloud Functions デプロイ
+
+`.github/workflows/deploy.yaml` が main への push と手動実行(`workflow_dispatch`)で
+`firebase deploy --only functions` を実行する。認証は Workload Identity 連携を使い、
+長期の認証情報は GitHub に置かない。
+
+### GCP 側のセットアップ（初回のみ）
+
+```bash
+PROJECT_ID=fir-cloud-functions-trial
+PROJECT_NUMBER=830437244276
+REPO=yutak23/firebase-trial
+SA=github-actions-deployer@${PROJECT_ID}.iam.gserviceaccount.com
+
+# デプロイ用サービスアカウント
+gcloud iam service-accounts create github-actions-deployer \
+  --project=$PROJECT_ID --display-name="GitHub Actions Deployer"
+
+# ロール付与
+for ROLE in \
+  roles/firebase.admin \
+  roles/cloudfunctions.admin \
+  roles/iam.serviceAccountUser \
+  roles/artifactregistry.writer \
+  roles/cloudbuild.builds.editor \
+  roles/serviceusage.serviceUsageConsumer \
+  roles/secretmanager.admin
+do
+  gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:${SA}" --role="$ROLE"
+done
+
+# Workload Identity プール / プロバイダ（attribute-condition は必須）
+gcloud iam workload-identity-pools create github \
+  --project=$PROJECT_ID --location=global --display-name="GitHub Actions Pool"
+
+gcloud iam workload-identity-pools providers create-oidc firebase-trial \
+  --project=$PROJECT_ID --location=global \
+  --workload-identity-pool=github --display-name="firebase-trial" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
+  --attribute-condition="assertion.repository_owner == 'yutak23'" \
+  --issuer-uri="https://token.actions.githubusercontent.com"
+
+# このリポジトリからのみ SA を借用できるようにバインド
+gcloud iam service-accounts add-iam-policy-binding $SA \
+  --project=$PROJECT_ID --role=roles/iam.workloadIdentityUser \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/attribute.repository/${REPO}"
+```
+
+`iam.serviceAccountUser` はランタイムSAとして関数を動かすため、`secretmanager.admin` は
+デプロイ時に `GEMINI_API_KEY` のバージョン解決とバインドを行うために必要。
+
+### GitHub 側のセットアップ
+
+`Settings` →`Secrets and variables` →`Actions` →`Variables`タブに登録する
+（秘密情報ではないので Secrets ではなく Variables）。
+
+| 名前                             | 値                                                                                             |
+| -------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/830437244276/locations/global/workloadIdentityPools/github/providers/firebase-trial` |
+| `GCP_DEPLOY_SERVICE_ACCOUNT`     | `github-actions-deployer@fir-cloud-functions-trial.iam.gserviceaccount.com`                    |
+
+### デプロイ対象について
+
+CI では `--only functions` のみを対象にしている。BigQuery 拡張機能5個は CI で触ると
+パラメータ入力待ちや意図しない再構成のリスクがあるため除外している。
+Hosting は Cloudflare Pages なので元々対象外。
+
 ## システム構成
 
 - Hosting  

--- a/README.md
+++ b/README.md
@@ -39,13 +39,19 @@ GCP コンソールから設定できる。コード側の変更は不要
    を開く（初回は Secret Manager API の有効化が必要）
 2. `シークレットを作成`をクリックし、名前に `GEMINI_API_KEY`（コード内の参照名と完全一致させる）、
    値に取得した API キーを入力して作成
-3. Cloud Functions のランタイムサービスアカウント
-   `fir-cloud-functions-trial@appspot.gserviceaccount.com` に
-   `Secret Manager のシークレット アクセサー`(`roles/secretmanager.secretAccessor`)が
-   付与されているかを、該当シークレットの`権限`タブで確認する
-   （デプロイ時に自動付与されることが多いが、付かない場合がある）
+3. 作成したシークレットの`権限`タブ →`アクセスを許可`で、Cloud Functions の
+   ランタイムサービスアカウント `fir-cloud-functions-trial@appspot.gserviceaccount.com` に
+   `Secret Manager のシークレット アクセサー`(`roles/secretmanager.secretAccessor`)を付与する。
+   `ロール別に表示`に切り替えて`シークレット アクセサー`の下に当該サービスアカウントが
+   入っていれば設定完了
 4. `yarn deploy:exclude:hosting` でデプロイし、Cloud Functions のログに
    `scanReceipt` の起動エラー（シークレット参照失敗）が出ていないことを確認
+
+App Engine のデフォルトサービスアカウントはプロジェクトレベルで`編集者`を継承しているため、
+権限タブに`編集者`として表示されることがあるが、**これではシークレットの値を読めない**。
+[公式ドキュメント](https://docs.cloud.google.com/secret-manager/docs/access-control)のとおり
+`secretmanager.versions.access` はオーナーには含まれるが編集者・閲覧者には含まれないため、
+手順3の`シークレット アクセサー`の付与は必須。
 
 ## システム構成
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ API キーの設定が必要。
 - [Google AI Studio](https://aistudio.google.com/apikey) で API キーを取得
 
 - ローカル（エミュレータ）  
-  `firebase-cloud-functions/.env.local` に `GEMINI_API_KEY=<取得したキー>` を記載（gitignore 済み）
+  `firebase-cloud-functions/.secret.local` に `GEMINI_API_KEY=<取得したキー>` を記載（gitignore 済み）。
+  `runWith({ secrets: [...] })` で宣言したシークレットは `.env.local` からは読み込まれず、
+  エミュレータは `.secret.local` を参照する
 
 - 本番  
   `npx firebase functions:secrets:set GEMINI_API_KEY` でシークレットを登録してから

--- a/README.md
+++ b/README.md
@@ -107,6 +107,36 @@ gcloud iam service-accounts add-iam-policy-binding $SA \
 `iam.serviceAccountUser` はランタイムSAとして関数を動かすため、`secretmanager.admin` は
 デプロイ時に `GEMINI_API_KEY` のバージョン解決とバインドを行うために必要。
 
+### プールやプロバイダが既に存在する場合
+
+`ALREADY_EXISTS` が返る場合、`create` は既存の設定を上書きしないため、中身が
+意図したものになっているかを確認する。特に `attributeMapping` に
+`attribute.repository` が無いと、上記のバインドと一致せず認証に失敗する。
+
+```bash
+gcloud iam workload-identity-pools providers describe firebase-trial \
+  --project=$PROJECT_ID --location=global --workload-identity-pool=github \
+  --format="yaml(attributeMapping, attributeCondition, state, disabled, oidc)"
+
+# デプロイSAに実際に付いているロールの一覧
+gcloud projects get-iam-policy $PROJECT_ID \
+  --flatten="bindings[].members" \
+  --filter="bindings.members:${SA}" \
+  --format="value(bindings.role)"
+```
+
+設定が異なっていれば `update-oidc` で合わせる。
+
+```bash
+gcloud iam workload-identity-pools providers update-oidc firebase-trial \
+  --project=$PROJECT_ID --location=global --workload-identity-pool=github \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
+  --attribute-condition="assertion.repository_owner == 'yutak23'"
+```
+
+`state` が `DELETED` の場合は削除済みの名前が30日間予約されている状態。
+`undelete` するか、別名で作り直してバインドと GitHub Variables を貼り替える。
+
 ### GitHub 側のセットアップ
 
 `Settings` →`Secrets and variables` →`Actions` →`Variables`タブに登録する

--- a/README.md
+++ b/README.md
@@ -3,12 +3,28 @@
 以下を検証。
 
 - firebase emulators を使った開発
-
   - auth
   - functions
   - firestore
 
 - firebase deploy でインフラ構築
+
+## レシート撮影による自動入力
+
+家計簿の登録ダイアログでレシートを撮影すると、日付・金額・カテゴリ・店名（メモ）を自動補完する。
+画像は解析に使うだけで保存しない。
+
+解析は Cloud Functions の `scanReceipt`（callable, App Check 必須）から Gemini API を呼んで行うため、
+API キーの設定が必要。
+
+- [Google AI Studio](https://aistudio.google.com/apikey) で API キーを取得
+
+- ローカル（エミュレータ）  
+  `firebase-cloud-functions/.env.local` に `GEMINI_API_KEY=<取得したキー>` を記載（gitignore 済み）
+
+- 本番  
+  `npx firebase functions:secrets:set GEMINI_API_KEY` でシークレットを登録してから
+  `yarn deploy:exclude:hosting` でデプロイ
 
 ## システム構成
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@ API キーの設定が必要。
   `npx firebase functions:secrets:set GEMINI_API_KEY` でシークレットを登録してから
   `yarn deploy:exclude:hosting` でデプロイ
 
+キーはリポジトリが public のためソースコードに直書きしないこと。
+`src/`配下に置くと Vite がバンドルに埋め込み、全訪問者に配布されるので特に不可。
+
+### CLI を使わずコンソールから設定する場合
+
+Firebase コンソールにシークレットの管理画面はないが、実体は Google Cloud Secret Manager なので
+GCP コンソールから設定できる。コード側の変更は不要
+（`runWith({ secrets: ['GEMINI_API_KEY'] })` がそのまま参照する）。
+
+1. [Secret Manager](https://console.cloud.google.com/security/secret-manager?project=fir-cloud-functions-trial)
+   を開く（初回は Secret Manager API の有効化が必要）
+2. `シークレットを作成`をクリックし、名前に `GEMINI_API_KEY`（コード内の参照名と完全一致させる）、
+   値に取得した API キーを入力して作成
+3. Cloud Functions のランタイムサービスアカウント
+   `fir-cloud-functions-trial@appspot.gserviceaccount.com` に
+   `Secret Manager のシークレット アクセサー`(`roles/secretmanager.secretAccessor`)が
+   付与されているかを、該当シークレットの`権限`タブで確認する
+   （デプロイ時に自動付与されることが多いが、付かない場合がある）
+4. `yarn deploy:exclude:hosting` でデプロイし、Cloud Functions のログに
+   `scanReceipt` の起動エラー（シークレット参照失敗）が出ていないことを確認
+
 ## システム構成
 
 - Hosting  

--- a/firebase-cloud-functions/index.js
+++ b/firebase-cloud-functions/index.js
@@ -7,6 +7,7 @@ import lodash from 'lodash';
 // eslint-disable-next-line import/extensions
 import md5 from 'crypto-js/md5.js';
 import { BigQuery } from '@google-cloud/bigquery';
+import { GoogleGenAI, Type } from '@google/genai';
 
 const { omit } = lodash;
 const isLocal = process.env.NODE_ENV === 'local';
@@ -193,6 +194,156 @@ export const replyInvite = functions
 		// TODO rejectの場合を実装
 
 		return { type };
+	});
+
+// レシート画像から家計簿の入力内容を推定する
+const RECEIPT_MODEL = 'gemini-2.5-flash';
+const RECEIPT_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+const RECEIPT_MAX_IMAGE_BYTES = 2 * 1024 * 1024;
+const RECEIPT_CATEGORIES = [
+	'food_expenses',
+	'commodity_expenses',
+	'medical_expense',
+	'clothing_expenses',
+	'transportation_expenses',
+	'rent_expenses',
+	'utilities_expense',
+	'maternity_baby_expense',
+	'another_expense'
+];
+const RECEIPT_PROMPT = `あなたは日本語のレシートを読み取るアシスタントです。
+添付されたレシート画像から以下の情報を抽出し、JSONで返してください。
+
+- totalPrice: 実際に支払った金額（円、整数）。
+  「合計」「お買上計」「税込合計」などの行を採用すること。
+  「小計」「課税対象額」「お預り」「お釣り」「ポイント」は採用しないこと。
+  クーポンや値引きが適用されている場合は、値引き後の実支払額を採用すること。
+  画像がレシートではない、または金額が読み取れない場合は 0 にすること。
+- date: レシートの発行日を yyyy-MM-dd 形式で。読み取れない場合は空文字にすること。
+  和暦の場合は西暦に変換すること。
+- storeName: 店舗の屋号のみ。支店名・住所・電話番号・法人格は含めないこと。
+  読み取れない場合は空文字にすること。
+- category: 購入内容から最も近いものを次のIDから1つだけ選ぶこと。
+  food_expenses（食費）, commodity_expenses（日用品費）, medical_expense（医療費）,
+  clothing_expenses（服飾費）, transportation_expenses（交通費）, rent_expenses（家賃）,
+  utilities_expense（水道光熱費）, maternity_baby_expense（妊婦/Baby費）,
+  another_expense（その他）
+  判断できない場合は another_expense にすること。`;
+
+const genAi = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
+
+// モデルの出力は信用せず、アプリが扱える値に丸めてから返す
+const sanitizeReceipt = (parsed) => {
+	const price =
+		Number.isInteger(parsed.totalPrice) && parsed.totalPrice > 0
+			? parsed.totalPrice
+			: null;
+
+	const date =
+		typeof parsed.date === 'string' &&
+		/^\d{4}-\d{2}-\d{2}$/.test(parsed.date) &&
+		!Number.isNaN(new Date(parsed.date).getTime())
+			? parsed.date
+			: null;
+
+	const storeName =
+		typeof parsed.storeName === 'string' && parsed.storeName.trim() !== ''
+			? parsed.storeName.trim().slice(0, 100)
+			: null;
+
+	const category = RECEIPT_CATEGORIES.includes(parsed.category)
+		? parsed.category
+		: 'another_expense';
+
+	return { date, storeName, price, category };
+};
+
+export const scanReceipt = functions
+	.region('asia-northeast1')
+	.runWith({
+		enforceAppCheck: true,
+		secrets: ['GEMINI_API_KEY'],
+		memory: '512MB',
+		timeoutSeconds: 60
+	})
+	.https.onCall(async (data, context) => {
+		// エミュレータではApp Checkが検証されずcontext.appがundefinedになる
+		if (!isLocal && context.app === undefined) {
+			throw new functions.https.HttpsError(
+				'failed-precondition',
+				'The function must be called from an App Check verified app.'
+			);
+		}
+
+		if (!context.auth)
+			throw new functions.https.HttpsError(
+				'unauthenticated',
+				'The function must be called while authenticated.'
+			);
+
+		if (
+			!('imageBase64' in data) ||
+			typeof data.imageBase64 !== 'string' ||
+			data.imageBase64 === '' ||
+			!('mimeType' in data) ||
+			!RECEIPT_MIME_TYPES.includes(data.mimeType)
+		)
+			throw new functions.https.HttpsError(
+				'invalid-argument',
+				'invalid request.'
+			);
+
+		const { imageBase64, mimeType } = data;
+
+		// base64は元データの約4/3の長さになる
+		if ((imageBase64.length * 3) / 4 > RECEIPT_MAX_IMAGE_BYTES)
+			throw new functions.https.HttpsError(
+				'invalid-argument',
+				'image is too large.'
+			);
+
+		let parsed;
+		try {
+			const response = await genAi.models.generateContent({
+				model: RECEIPT_MODEL,
+				contents: [
+					{ inlineData: { data: imageBase64, mimeType } },
+					{ text: RECEIPT_PROMPT }
+				],
+				config: {
+					responseMimeType: 'application/json',
+					responseSchema: {
+						type: Type.OBJECT,
+						properties: {
+							date: { type: Type.STRING },
+							storeName: { type: Type.STRING },
+							totalPrice: { type: Type.INTEGER },
+							category: { type: Type.STRING }
+						},
+						required: ['date', 'storeName', 'totalPrice', 'category'],
+						propertyOrdering: ['date', 'storeName', 'totalPrice', 'category']
+					}
+				}
+			});
+			parsed = JSON.parse(response.text);
+		} catch (e) {
+			// 画像や抽出結果自体はログに残さない
+			functions.logger.error('scanReceipt failure', e);
+			throw new functions.https.HttpsError(
+				'internal',
+				'failed to scan receipt.'
+			);
+		}
+
+		const result = sanitizeReceipt(parsed);
+
+		functions.logger.info(
+			'scanReceipt success',
+			`uid: ${context.auth.uid}`,
+			`detected: ${result.price !== null}`
+		);
+
+		return result;
 	});
 
 // 検証用 テンポラリー

--- a/firebase-cloud-functions/package.json
+++ b/firebase-cloud-functions/package.json
@@ -17,6 +17,7 @@
 	"main": "index.js",
 	"dependencies": {
 		"@google-cloud/bigquery": "^8.1.1",
+		"@google/genai": "^2.16.0",
 		"camelcase-keys": "^9.1.3",
 		"crypto-js": "^4.2.0",
 		"firebase-admin": "^13.4.0",

--- a/firebase-cloud-functions/yarn.lock
+++ b/firebase-cloud-functions/yarn.lock
@@ -212,6 +212,16 @@
     teeny-request "^9.0.0"
     uuid "^8.0.0"
 
+"@google/genai@^2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@google/genai/-/genai-2.16.0.tgz#de943aff150dda28e7c08d5ac8781748c928ee27"
+  integrity sha512-K+1C1sqR0u7NJ5xpKJCQBws0QXpfuklo3WTNuUIMvtbQfNW2O5OohX0BYT2V+PXzsUzQEwGCXPWQxttLyGQ6xw==
+  dependencies:
+    google-auth-library "^10.3.0"
+    p-retry "^4.6.2"
+    protobufjs "^7.5.4"
+    ws "^8.18.0"
+
 "@grpc/grpc-js@~1.10.3":
   version "1.10.8"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.10.8.tgz#99787785cd8335be861afd1cd485ae9f058e4484"
@@ -306,10 +316,20 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
   integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
 
+"@protobufjs/codegen@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.5.tgz#d9315ad7cf3f30aac70bda3c068443dc6f143659"
+  integrity sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==
+
 "@protobufjs/eventemitter@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
   integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
+
+"@protobufjs/eventemitter@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz#d512cb26c0ae026091ee2c1167f1be6faf5c842a"
+  integrity sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==
 
 "@protobufjs/fetch@^1.1.0":
   version "1.1.0"
@@ -318,6 +338,13 @@
   dependencies:
     "@protobufjs/aspromise" "^1.1.1"
     "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/fetch@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.1.tgz#4d6fc00c8fb64016a5c81b469d549046350f1065"
+  integrity sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
 
 "@protobufjs/float@^1.0.2":
   version "1.0.2"
@@ -343,6 +370,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
+
+"@protobufjs/utf8@^1.1.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.2.tgz#78d476333d85d5b1c792e257bca74ba080da49a4"
+  integrity sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -463,6 +495,11 @@
     "@types/node" "*"
     "@types/tough-cookie" "*"
     form-data "^2.5.0"
+
+"@types/retry@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
 "@types/serve-static@*":
   version "1.15.1"
@@ -1943,6 +1980,24 @@ gaxios@^7.0.0:
     https-proxy-agent "^7.0.1"
     node-fetch "^3.3.2"
 
+gaxios@^7.1.4:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-7.3.0.tgz#d4a7e2895898b9387dd5c2e0683607eff4345118"
+  integrity sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==
+  dependencies:
+    extend "^3.0.2"
+    https-proxy-agent "^7.0.1"
+    node-fetch "^3.3.2"
+
+gcp-metadata@8.1.2:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-8.1.2.tgz#e62e3373ddf41fc727ccc31c55c687b798bee898"
+  integrity sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==
+  dependencies:
+    gaxios "^7.0.0"
+    google-logging-utils "^1.0.0"
+    json-bigint "^1.0.0"
+
 gcp-metadata@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-6.1.0.tgz#9b0dd2b2445258e7597f2024332d20611cbd6b8c"
@@ -2109,6 +2164,18 @@ google-auth-library@^10.0.0-rc.1:
     gtoken "^8.0.0"
     jws "^4.0.0"
 
+google-auth-library@^10.3.0:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-10.9.1.tgz#af9852a328a6077e8ffbe776681b4ca9420a1714"
+  integrity sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==
+  dependencies:
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    gaxios "^7.1.4"
+    gcp-metadata "8.1.2"
+    google-logging-utils "1.1.3"
+    jws "^4.0.0"
+
 google-auth-library@^9.14.2, google-auth-library@^9.6.3:
   version "9.15.0"
   resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-9.15.0.tgz#1b009c08557929c881d72f953f17e839e91b009b"
@@ -2150,6 +2217,11 @@ google-gax@^4.3.3:
     protobufjs "7.3.0"
     retry-request "^7.0.0"
     uuid "^9.0.1"
+
+google-logging-utils@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-1.1.3.tgz#17b71f1f95d266d2ddd356b8f00178433f041b17"
+  integrity sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==
 
 google-logging-utils@^1.0.0:
   version "1.1.1"
@@ -2868,6 +2940,11 @@ long@^5.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
   integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
 
+long@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
+
 lower-case@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
@@ -3169,6 +3246,14 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
+p-retry@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
+  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
+  dependencies:
+    "@types/retry" "0.12.0"
+    retry "^0.13.1"
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -3276,6 +3361,23 @@ protobufjs@^7.2.5:
     "@protobufjs/utf8" "^1.1.0"
     "@types/node" ">=13.7.0"
     long "^5.0.0"
+
+protobufjs@^7.5.4:
+  version "7.6.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.5.tgz#7b9250cdaf4a06139a9f0fe468a40d7d4febca71"
+  integrity sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.5"
+    "@protobufjs/eventemitter" "^1.1.1"
+    "@protobufjs/fetch" "^1.1.1"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.1"
+    "@types/node" ">=13.7.0"
+    long "^5.3.2"
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -3422,7 +3524,7 @@ retry-request@^8.0.0:
     extend "^3.0.2"
     teeny-request "^10.0.0"
 
-retry@0.13.1:
+retry@0.13.1, retry@^0.13.1:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
   integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
@@ -4337,6 +4439,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@^8.18.0:
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.3.tgz#660b4faddb6a3e575c86e078126919961f4de4fc"
+  integrity sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -23,7 +23,12 @@
 				"maternity_baby_expense": "妊婦/Baby費",
 				"another_expense": "その他"
 			},
-			"member": { "joint": "共同" }
+			"member": { "joint": "共同" },
+			"receipt": {
+				"button": "レシートを撮影して自動入力",
+				"not_found": "レシートから金額を読み取れませんでした。手入力してください",
+				"error": "レシートの解析に失敗しました。もう一度お試しください"
+			}
 		}
 	},
 	"$vuetify": {

--- a/src/service/receipt-service.js
+++ b/src/service/receipt-service.js
@@ -1,0 +1,14 @@
+import { httpsCallable } from 'firebase/functions';
+
+import { functions } from '@/firebase';
+
+const scanReceiptFunc = httpsCallable(functions, 'scanReceipt');
+
+// { date, storeName, price, category } を返す
+const scanReceipt = async ({ imageBase64, mimeType }) => {
+	const { data } = await scanReceiptFunc({ imageBase64, mimeType });
+	return data;
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export { scanReceipt };

--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -1,0 +1,30 @@
+// 撮影画像をそのまま送るとモバイルでは数MBになるため、送信前に縮小する
+const fileToResizedBase64 = async (file, options = {}) => {
+	const { maxEdge = 1600, quality = 0.8 } = options;
+
+	let bitmap;
+	try {
+		bitmap = await createImageBitmap(file);
+	} catch (e) {
+		// HEICなどブラウザがデコードできない形式
+		throw new Error('unsupported image format');
+	}
+
+	const scale = Math.min(1, maxEdge / Math.max(bitmap.width, bitmap.height));
+	const canvas = document.createElement('canvas');
+	canvas.width = Math.round(bitmap.width * scale);
+	canvas.height = Math.round(bitmap.height * scale);
+
+	canvas.getContext('2d').drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+	bitmap.close();
+
+	const dataUrl = canvas.toDataURL('image/jpeg', quality);
+
+	return {
+		imageBase64: dataUrl.slice(dataUrl.indexOf(',') + 1),
+		mimeType: 'image/jpeg'
+	};
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export { fileToResizedBase64 };

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -41,9 +41,16 @@ const closeLoading = () => {
 const bottomNavigation = ref(false);
 
 const bookDataDialog = ref(false);
+// ダイアログを開き直すたびに採番し、進行中のスキャンの結果を破棄するために使う
+let formInstanceId = 0;
+const scanning = ref(false);
+const scanError = ref(null);
 const datePickDialog = ref(false);
 const datepicker = ref(null);
 const openBookDataDialog = () => {
+	formInstanceId += 1; // 進行中のスキャン結果を無効化する
+	scanning.value = false;
+	scanError.value = null;
 	bookDataDialog.value = true;
 	bottomNavigation.value = null;
 };
@@ -117,8 +124,6 @@ const cateories = computed(() => [
 	}
 ]);
 const receiptInput = ref(null);
-const scanning = ref(false);
-const scanError = ref(null);
 const openReceiptInput = () => {
 	receiptInput.value.click();
 };
@@ -128,11 +133,19 @@ const onReceiptSelected = async (event) => {
 	receiptInput.value.value = ''; // 同じ写真を選び直せるようにする
 	if (!file) return;
 
+	// 解析中にダイアログを閉じて別のフォームを開かれた場合、
+	// 遅れて届いた結果で今のフォームを書き換えないようにする
+	const scanTarget = formInstanceId;
+	const isStale = () => scanTarget !== formInstanceId || !bookDataDialog.value;
+
 	scanning.value = true;
 	scanError.value = null;
 	try {
 		const { imageBase64, mimeType } = await fileToResizedBase64(file);
+		if (isStale()) return;
+
 		const result = await scanReceipt({ imageBase64, mimeType });
+		if (isStale()) return;
 
 		// レシートとして何も読み取れなかった場合はフォームを書き換えない
 		if (!result.price && !result.date && !result.storeName) {
@@ -151,10 +164,12 @@ const onReceiptSelected = async (event) => {
 		if (!result.price)
 			scanError.value = t('groups.add_book_data_dialog.receipt.not_found');
 	} catch (e) {
+		if (isStale()) return;
 		console.error(e);
 		scanError.value = t('groups.add_book_data_dialog.receipt.error');
 	} finally {
-		scanning.value = false;
+		// 古いスキャンが後発スキャンのローディング状態を消さないようにする
+		if (!isStale()) scanning.value = false;
 	}
 };
 
@@ -166,7 +181,6 @@ const create = () => {
 		}
 		book[key] = null;
 	});
-	scanError.value = null;
 	openBookDataDialog();
 };
 
@@ -236,7 +250,6 @@ const getAllCurrentData = async (options = {}) => {
 	if (options.loading) closeLoading();
 };
 const edit = (v) => {
-	scanError.value = null;
 	book.id = v.id;
 	book.date = v.date;
 	book.price = v.price;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -21,6 +21,8 @@ import '@vuepic/vue-datepicker/dist/main.css';
 import { db } from '@/firebase';
 import { converter } from '@/firebase/store';
 import { fetchGroupMembers } from '@/service/group-service';
+import { scanReceipt } from '@/service/receipt-service';
+import { fileToResizedBase64 } from '@/utils/image';
 
 const { t } = useI18n();
 const props = defineProps({
@@ -114,6 +116,48 @@ const cateories = computed(() => [
 		value: 'another_expense'
 	}
 ]);
+const receiptInput = ref(null);
+const scanning = ref(false);
+const scanError = ref(null);
+const openReceiptInput = () => {
+	receiptInput.value.click();
+};
+// レシートを読み取ってフォームを埋めるだけで、登録はユーザーの操作に任せる
+const onReceiptSelected = async (event) => {
+	const file = event.target.files[0];
+	receiptInput.value.value = ''; // 同じ写真を選び直せるようにする
+	if (!file) return;
+
+	scanning.value = true;
+	scanError.value = null;
+	try {
+		const { imageBase64, mimeType } = await fileToResizedBase64(file);
+		const result = await scanReceipt({ imageBase64, mimeType });
+
+		// レシートとして何も読み取れなかった場合はフォームを書き換えない
+		if (!result.price && !result.date && !result.storeName) {
+			scanError.value = t('groups.add_book_data_dialog.receipt.not_found');
+			return;
+		}
+
+		const scannedDate = result.date
+			? DateTime.fromFormat(result.date, 'yyyy-MM-dd')
+			: null;
+		if (scannedDate && scannedDate.isValid) book.date = scannedDate.toJSDate();
+		if (result.price) book.price = result.price;
+		if (result.category) book.cateory = result.category;
+		if (result.storeName && !book.memo) book.memo = result.storeName;
+
+		if (!result.price)
+			scanError.value = t('groups.add_book_data_dialog.receipt.not_found');
+	} catch (e) {
+		console.error(e);
+		scanError.value = t('groups.add_book_data_dialog.receipt.error');
+	} finally {
+		scanning.value = false;
+	}
+};
+
 const create = () => {
 	Object.keys(book).forEach((key) => {
 		if (key === 'date') {
@@ -122,6 +166,7 @@ const create = () => {
 		}
 		book[key] = null;
 	});
+	scanError.value = null;
 	openBookDataDialog();
 };
 
@@ -191,6 +236,7 @@ const getAllCurrentData = async (options = {}) => {
 	if (options.loading) closeLoading();
 };
 const edit = (v) => {
+	scanError.value = null;
 	book.id = v.id;
 	book.date = v.date;
 	book.price = v.price;
@@ -362,6 +408,35 @@ await getAllCurrentData();
 				<v-card-text>
 					<v-form ref="form">
 						<v-row>
+							<v-col cols="12" class="pb-0">
+								<v-btn
+									block
+									variant="tonal"
+									prepend-icon="mdi-camera"
+									:loading="scanning"
+									@click="openReceiptInput"
+								>
+									{{ $t('groups.add_book_data_dialog.receipt.button') }}
+								</v-btn>
+								<!-- スマホでカメラを直接起動するため v-file-input ではなく input を使う -->
+								<input
+									ref="receiptInput"
+									type="file"
+									accept="image/*"
+									capture="environment"
+									class="d-none"
+									@change="onReceiptSelected"
+								/>
+								<v-alert
+									v-if="scanError"
+									type="warning"
+									density="compact"
+									variant="tonal"
+									class="mt-2"
+								>
+									{{ scanError }}
+								</v-alert>
+							</v-col>
 							<v-col cols="12">
 								<v-text-field
 									v-model="dispalyDate"


### PR DESCRIPTION
登録ダイアログでレシートを撮影すると、日付・金額・カテゴリ・店名(メモ)を
自動で埋めるようにした。フォームを埋めるだけで登録はユーザー操作に任せる。

- scanReceipt callable を追加。App Check 必須で Gemini API を呼び、
  レシート画像から構造化JSONを取得する。APIキーは Secret で秘匿
- モデル出力は信用せず、カテゴリ・金額・日付をサニタイズしてから返す
- 送信前に長辺1600pxのJPEGへ縮小し、ペイロードとトークンを削減
- 撮影画像は解析に使うだけで保存しないため、Firestore のデータモデルと
  セキュリティルールは変更なし