### PR TITLE
fix: CIデプロイの前提となるCloud Billing APIの有効化を明記

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ PROJECT_NUMBER=830437244276
 REPO=yutak23/firebase-trial
 SA=github-actions-deployer@${PROJECT_ID}.iam.gserviceaccount.com
 
+# Cloud Billing API（Firebase CLI が functions デプロイ時に課金状態を確認するため必要）
+# cloudfunctions / cloudbuild / artifactregistry / secretmanager は CLI が自動で
+# 有効化するが、これだけは事前に有効化しておく必要がある
+gcloud services enable cloudbilling.googleapis.com --project=$PROJECT_ID
+
 # デプロイ用サービスアカウント
 gcloud iam service-accounts create github-actions-deployer \
   --project=$PROJECT_ID --display-name="GitHub Actions Deployer"

--- a/firebase-cloud-functions/index.js
+++ b/firebase-cloud-functions/index.js
@@ -230,7 +230,13 @@ const RECEIPT_PROMPT = `あなたは日本語のレシートを読み取るア�
   another_expense（その他）
   判断できない場合は another_expense にすること。`;
 
-const genAi = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
+// デプロイ時のソース解析ではシークレットが注入されないため、
+// モジュール読み込み時ではなく最初の呼び出し時にクライアントを生成する
+let genAi = null;
+const getGenAi = () => {
+	if (!genAi) genAi = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
+	return genAi;
+};
 
 // モデルの出力は信用せず、アプリが扱える値に丸めてから返す
 const sanitizeReceipt = (parsed) => {
@@ -304,7 +310,7 @@ export const scanReceipt = functions
 
 		let parsed;
 		try {
-			const response = await genAi.models.generateContent({
+			const response = await getGenAi().models.generateContent({
 				model: RECEIPT_MODEL,
 				contents: [
 					{ inlineData: { data: imageBase64, mimeType } },


### PR DESCRIPTION
## 背景

PR #187 のマージで初回実行された `deploy` ワークフロー（[run 31358846171](https://github.com/yutak23/firebase-trial/actions/runs/31358846171)）が失敗した。

認証・権限まわりはすべて成功しており、シークレットのバインドまで完了していた。

```
✔ secretmanager: Granted roles/secretmanager.secretAccessor on
  projects/fir-cloud-functions-trial/secrets/GEMINI_API_KEY to
  fir-cloud-functions-trial@appspot.gserviceaccount.com
```

その直後に以下で失敗していた。

```
Error: Request to https://cloudbilling.googleapis.com/v1/projects/fir-cloud-functions-trial/billingInfo
had HTTP Error: 403, Cloud Billing API has not been used in project 830437244276
before or it is disabled.
```

権限拒否ではなく API 自体が未有効化（`SERVICE_DISABLED` 型）のエラー。Firebase CLI は functions デプロイ時に課金状態を確認するが、`cloudfunctions` / `cloudbuild` / `artifactregistry` / `secretmanager` と違い Cloud Billing API は自動で有効化されない。

## 変更内容

### `README.md`

CI セットアップ手順に `cloudbilling.googleapis.com` の有効化を追加した。他の API は CLI が自動有効化するが、これだけは事前に必要である旨も併記している。

```bash
gcloud services enable cloudbilling.googleapis.com --project=$PROJECT_ID
```

### `firebase-cloud-functions/index.js`

Gemini クライアントを遅延生成に変更した。

同じログに `API key should be set when using the Gemini API.` が2回出力されていた。モジュール読み込み時に `new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY })` を実行しているため、シークレットが注入されないデプロイ時のソース解析で警告が出ていた。

実行時は Cloud Functions がシークレットを環境変数として注入した後にコールドスタートするため動作自体に問題はないが、毎回のデプロイログにノイズが出るうえ、未定義キーでクライアントを固定するのは脆いため、最初の呼び出し時に生成するようにした。

## 確認したこと

- 修正前後を同条件（`GEMINI_API_KEY` 未設定でモジュール読み込み）で比較し、修正前は警告2回・修正後は0回になることを確認
- `yarn lint`（ルート／functions 両方）エラー0、`prettier --check` パス

## デプロイ側の対応

Cloud Billing API は有効化済み。このPRのマージで `deploy` ワークフローが走る。

マージ後の確認ポイント:

- `cloudbilling` の 403 が出ないこと
- `API key should be set when using the Gemini API.` が出なくなっていること
- `functions[scanReceipt(asia-northeast1)]` が作成されること

## 申し送り（本PRの対象外）

同じログに出ていた警告。今回の失敗とは無関係だが期限があるため記載する。

- `Runtime Node.js 20 was deprecated on 2026-04-30 and will be decommissioned on 2026-10-30` — 約2.5か月後に Node 20 ランタイムでデプロイできなくなる。動作確認を伴うため別対応が必要
- `package.json indicates an outdated version of firebase-functions` — v1 API を使い続けている都合

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLsFm6MGKYPRmVSQiYDD3R)_