### PR TITLE
fix(ci): Node.jsのバージョンをpackage.jsonのenginesから取得する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,11 +13,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      # package.json の engines.node を参照するため、
+      # Node.js のバージョン更新時にワークフローの修正が不要になる
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: 'package.json'
           cache: 'yarn'
 
       - name: yarn install

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,9 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # package.json の engines.node を参照するため、
+      # Node.js のバージョン更新時にワークフローの修正が不要になる
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: 'package.json'
           cache: 'yarn'
 
       # postinstall で firebase-cloud-functions 側の依存も入る


### PR DESCRIPTION
renovate/node-22.x（#136）のCIが `yarn install --frozen-lockfile` の engineチェックで失敗していた。ワークフローが `node-version: 20` を
ハードコードしている一方、PRでは package.json の engines.node が 22 に 更新されるため、`Expected version "22". Got "20.20.2"` となっていた。

setup-node の node-version-file に package.json を指定し、engines.node を 参照するように変更。これによりRenovateのNode.jsバージョン更新PRで
ワークフロー側の追従修正が不要になる。あわせてdeploy側も同様に変更し、
mainマージ後のデプロイが同じengineチェックで失敗しないようにした。

またci.yamlのactions/checkoutとactions/setup-nodeをv4に更新 （v3はNode 20 runner廃止に伴う非推奨警告が出ていたため）。


Claude-Session: https://claude.ai/code/session_011CapahLD2C5r9x4QF6MgQa