### PR TITLE
ci: add --force to functions deploy to fix cleanup policy failure

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,5 +45,8 @@ jobs:
           create_credentials_file: true
           export_environment_variables: true
 
+      # --force は Artifact Registry のクリーンアップポリシー設定の確認をスキップするために必要
+      # （未設定の場合、--non-interactive だけだとデプロイ成功後にエラー終了してしまう）
+      # デフォルトの保持期間（1日）でポリシーが自動設定される
       - name: deploy functions
-        run: npx firebase deploy --only functions --project fir-cloud-functions-trial --non-interactive
+        run: npx firebase deploy --only functions --project fir-cloud-functions-trial --non-interactive --force


### PR DESCRIPTION
Artifact Registry のクリーンアップポリシーが未設定のため、firebase CLI が
確認プロンプトを出そうとして --non-interactive でエラー終了し、
デプロイ自体は成功しているのに main の deploy ワークフローが失敗していた。
--force を付けてデフォルト保持期間でポリシーを自動設定するようにする。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SrFBLY8FJVNuHVQm8oWihS