### PR TITLE
fix: firebase-admin v14 のモジュラーAPIに移行してデプロイ失敗を解消

### DIFF
--- a/firebase-cloud-functions/index.js
+++ b/firebase-cloud-functions/index.js
@@ -1,6 +1,11 @@
 // eslint-disable-next-line import/no-unresolved
 import * as functions from 'firebase-functions/v1';
-import admin from 'firebase-admin';
+// firebase-admin v14 で名前空間API（admin.firestore() など）が削除されたため、
+// モジュラーAPIのサブパスから読み込む
+// eslint-disable-next-line import/no-unresolved
+import { initializeApp } from 'firebase-admin/app';
+// eslint-disable-next-line import/no-unresolved
+import { getFirestore } from 'firebase-admin/firestore';
 import camelcaseKeys from 'camelcase-keys';
 import snakecaseKeys from 'snakecase-keys';
 import lodash from 'lodash';
@@ -12,9 +17,9 @@ import { GoogleGenAI, Type } from '@google/genai';
 const { omit } = lodash;
 const isLocal = process.env.NODE_ENV === 'local';
 
-admin.initializeApp();
+initializeApp();
 
-const db = admin.firestore();
+const db = getFirestore();
 const bigquery = isLocal
 	? new BigQuery({ apiEndpoint: 'http://localhost:9050' })
 	: new BigQuery();


### PR DESCRIPTION
firebase-admin v14 で名前空間API（admin.firestore() など）が削除され、
ルートのエクスポートにはアプリ初期化系のAPIしか含まれなくなった。
このため deploy ワークフローのソース解析で
`TypeError: admin.firestore is not a function` が発生し、
"Functions codebase could not be analyzed successfully" で失敗していた。

firebase-admin/app の initializeApp と firebase-admin/firestore の
getFirestore を使うモジュラーAPIに置き換える。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VHdtGpeCw3ePVoUAC66CiY